### PR TITLE
Switch to esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.2",
   "description": "An ACME client for the browser that authenticates via DNS-01 challenge and supports LetsEncrypt by default.",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "test": "node test.js"
   },

--- a/package.json
+++ b/package.json
@@ -31,9 +31,5 @@
   "homepage": "https://github.com/JonahGroendal/acme-easy#readme",
   "dependencies": {
     "node-forge": "^0.10.0"
-  },
-  "devDependencies": {
-    "btoa": "^1.2.1",
-    "node-fetch": "^2.6.5"
   }
 }

--- a/runTests.js
+++ b/runTests.js
@@ -1,32 +1,30 @@
 const tests = []
 
-function test(name, fn) {
+function test (name, fn) {
   tests.push({ name, fn })
 }
 
-async function run(defineTests) {
+async function run (defineTests) {
   defineTests()
 
-  aTestFailed = false
+  let aTestFailed = false
 
-  for (let i=0; i<tests.length; i++) {
+  for (let i = 0; i < tests.length; i++) {
     try {
       // Wait for resolve if its a promise
-			await (async () => tests[i].fn())()
-			console.log('✅', tests[i].name)
-		} catch (e) {
+      await (async () => tests[i].fn())()
+      console.log('✅', tests[i].name)
+    } catch (e) {
       aTestFailed = true
-			console.log('❌', tests[i].name)
-			// log the stack of the error
-			console.log(e.stack)
-		}
+      console.log('❌', tests[i].name)
+      // log the stack of the error
+      console.log(e.stack)
+    }
   }
   console.log()
   console.log('done.')
 
-  if (aTestFailed)
-    process.exit(1);
+  if (aTestFailed) { process.exit(1) }
 }
 
-exports.run = run
-exports.test = test
+export { test, run }


### PR DESCRIPTION
Couple of things:

- Executed `standard * --fix` to format the code to look the same. it almost looked like you followed that pattern.
- Switched code to ESM `import / export` ( allows for top level await and other goodies )
- Updated the test to require node v18 that have fetch + atob built in globally
- removed the `window.` prefix from `window.crypto` as node have a spec'ed web crypto on the global scope now.
  - besides, you should now use `globalThis` instead of window, self or this... it's the new standard that exist in all env.
- removed all dev-dep
- updated workflow to test out v18 instead.